### PR TITLE
Switch to apikey, from access token

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,65 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "viam_flutter_provisioning_widget",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "viam_flutter_provisioning_widget (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "viam_flutter_provisioning_widget (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "bluetooth_provisioning",
+            "cwd": "example/bluetooth_provisioning",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "bluetooth_provisioning (profile mode)",
+            "cwd": "example/bluetooth_provisioning",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "bluetooth_provisioning (release mode)",
+            "cwd": "example/bluetooth_provisioning",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "hotspot_provisioning",
+            "cwd": "example/hotspot_provisioning",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "hotspot_provisioning (profile mode)",
+            "cwd": "example/hotspot_provisioning",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "hotspot_provisioning (release mode)",
+            "cwd": "example/hotspot_provisioning",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/example/hotspot_provisioning/lib/connect_hotspot_prefix_screen.dart
+++ b/example/hotspot_provisioning/lib/connect_hotspot_prefix_screen.dart
@@ -58,9 +58,9 @@ class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen>
   }
 
   Future<void> _createRobot() async {
-    final location = await _viam.appClient.createLocation(Consts.organizationId, 'TEST-${Random().nextInt(1000)}');
+    final location = await _viam.appClient.createLocation(Consts.organizationId, 'test-location-${Random().nextInt(1000)}');
     final String robotName = "tester-${Random().nextInt(1000)}";
-    debugPrint('robotName: $robotName');
+    debugPrint('robotName: $robotName, locationId: ${location.name}');
     final robotId = await _viam.appClient.newMachine(robotName, location.id);
     _robot = await _viam.appClient.getRobot(robotId);
     _mainPart = (await _viam.appClient.listRobotParts(robotId)).firstWhere((element) => element.mainPart);

--- a/example/hotspot_provisioning/lib/connect_hotspot_prefix_screen.dart
+++ b/example/hotspot_provisioning/lib/connect_hotspot_prefix_screen.dart
@@ -37,16 +37,24 @@ class _ConnectHotspotPrefixScreenState extends State<ConnectHotspotPrefixScreen>
   @override
   void initState() {
     super.initState();
-    _viam = Viam.withAccessToken(Consts.accessToken);
-    // you MUST create the robot before connecting to the hotspot
-    // once connected to the hotspot you can communicate with the machine, but will not have interet access
-    _createRobot();
+    _initViam();
   }
 
   @override
   void dispose() {
     _pollingTimer?.cancel();
     super.dispose();
+  }
+
+  Future<void> _initViam() async {
+    try {
+      _viam = await Viam.withApiKey(Consts.apiKeyId, Consts.apiKey);
+      // you MUST create the robot before connecting to the hotspot
+      // once connected to the hotspot you can communicate with the machine, but will not have interet access
+      _createRobot();
+    } catch (e) {
+      debugPrint('Error initializing Viam: $e');
+    }
   }
 
   Future<void> _createRobot() async {

--- a/example/hotspot_provisioning/lib/consts.dart
+++ b/example/hotspot_provisioning/lib/consts.dart
@@ -1,7 +1,9 @@
 class Consts {
-  static const String hotspotPrefix = 'hotspot';
-  static const String hotspotPassword = 'password';
+  static const String hotspotPrefix = '';
+  static const String hotspotPassword = '';
 
-  static const String accessToken = '';
+  static const String apiKeyId = '';
+  static const String apiKey = '';
+
   static const String organizationId = '';
 }

--- a/example/hotspot_provisioning/pubspec.yaml
+++ b/example/hotspot_provisioning/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     git:
       url: https://github.com/viamrobotics/plugin_wifi_connect
       ref: 0.0.2
-  viam_sdk: 0.5.1
+  viam_sdk: 0.6.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Will point to the viam-flutter-sdk PR, but this will require a change to work.

Earlier I couldn't get my setup w/ an api key to work, and took a second to realize why - the `Viam` implementation I think is outdated when using the init that it calls (vs. with an access token)

https://github.com/viamrobotics/viam-flutter-sdk/pull/385